### PR TITLE
ci: run ci_details.sh in before_script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ stages:
   - finish
 
 .base:
+  before_script:
+    - schutzbot/ci_details.sh
   after_script:
     - schutzbot/update_github_status.sh update
     - schutzbot/save_journal.sh

--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -37,13 +37,6 @@ echo "List of installed packages:"
 rpm -qa | sort
 echo "------------------------------------------------------------------------------"
 
-if rpm --quiet -q python36; then
-    echo -e "\n FAIL: python36 is installed, see #794 ..."
-    exit 1
-else
-    echo -e "\n PASS: python36 not insalled"
-fi
-
 # Ensure cloud-init has completely finished on the instance. This ensures that
 # the instance is fully ready to go.
 while true; do


### PR DESCRIPTION
This is a nice script showing potentially useful details about the
runner so let's execute it at the begining of each job.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
